### PR TITLE
Add contribution heatmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ A Neofetch-Like program for Github profiles
 $ sudo curl https://raw.githubusercontent.com/isa-programmer/githubfetch/refs/heads/main/githubfetch.py -o /usr/local/bin/githubfetch
 $ sudo chmod +x /usr/local/bin/githubfetch
 ```
+Create a GitHub personal access token [here]("https://github.com/settings/tokens") with the ```read:user``` scope, then add this line to your .bashrc or other shell config and source it.
+```
+export GITHUB_TOKEN="your_personal_access_token_here"
+```
 
 ## Usage
 ```

--- a/githubfetch.py
+++ b/githubfetch.py
@@ -143,18 +143,31 @@ def display_user_info(data, starred_count, username):
 
 if __name__ == '__main__':
     if len(sys.argv) < 2:
-        print("Usage: githubfetch <your-github-username>")
+        print("Usage: githubfetch <username> [--heatmap]")
         sys.exit(1)
 
+    if sys.argv[1] in ['--help', '-h']:
+        print("Usage: githubfetch <username> [--heatmap]")
+        print("  --heatmap : show contribution graph (requires GITHUB_TOKEN)")
+        print("  -h, --help : show this help message and exit")
+        sys.exit(0)
+
     username = sys.argv[1]
+    heatmap = '--heatmap' in sys.argv
 
     try:
         user_data = get_user_data(username)
         starred_count = get_starred_count(username)
         display_avatar(user_data.get('avatar_url'))
         display_user_info(user_data, starred_count, username)
-        contributions = fetch_contributions(username)
-        display_contributions(contributions)
+
+        if heatmap:
+            token = os.getenv("GITHUB_TOKEN")
+            if not token:
+                print(color.color(color.yellow, "Warning: GITHUB_TOKEN not set. Skipping heatmap."))
+            else:
+                contributions = fetch_contributions(username)
+                display_contributions(contributions)
 
     except Exception as e:
         print(color.color(color.red, str(e)))


### PR DESCRIPTION
### Feature: GitHub Contributions Heatmap

Adds a new feature that fetches and displays a user's GitHub contributions heatmap directly in the terminal.

- Uses GitHub GraphQL API instead of scraping
- Renders a colored weekly heatmap in terminal
- Requires a GitHub personal access token via `$GITHUB_TOKEN` env variable
- Updated README to include token creation 

![20250611_13h54m35s_grim](https://github.com/user-attachments/assets/5bc23932-04f8-4de2-9d62-f9f5e68d8226)


Tested locally and falls back gracefully on error. Hope this adds a nice visual touch!

Could possibly work on additional customization through command line arguments (eg. `--compact` flag to make the heatmap smaller and more compact or `--no-avatar` to avoid displaying profile avatar)