### PR TITLE
docs: update README with usage and GITHUB_TOKEN instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,23 @@ A Neofetch-Like program for Github profiles
 $ sudo curl https://raw.githubusercontent.com/isa-programmer/githubfetch/refs/heads/main/githubfetch.py -o /usr/local/bin/githubfetch
 $ sudo chmod +x /usr/local/bin/githubfetch
 ```
-Create a GitHub personal access token [here]("https://github.com/settings/tokens") with the ```read:user``` scope, then add this line to your .bashrc or other shell config and source it.
+
+### Optional: Contribution heatmap
+Displaying the contribution heatmap along with basic user info requires a GitHub personal access token. Create one from [here](https://github.com/settings/tokens) with ```read:user``` scope, then add this line to your .bashrc or other shell config
 ```
 export GITHUB_TOKEN="your_personal_access_token_here"
 ```
 
 ## Usage
+### Basic user info
 ```
 $ githubfetch isa-programmer
 ```
+
+### With contribution heatmap
+```
+$ githubfetch <github-username> --heatmap
+```
+
 ## Example output
 ![example image](https://i.imgur.com/NdmszFZ.png)


### PR DESCRIPTION
Improves README to provide:
- Clear usage instructions for `githubfetch`
- Explanation of the `--heatmap` flag and when a token is needed

Aims to make it clear that the token setup is optional and required only for the heatmap option.

## Notes
- No code changes in this PR
- Based on feedback from the previous PR #6 