### PR TITLE
add_kitty_to_subprocess

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,47 @@ $ sudo curl https://raw.githubusercontent.com/isa-programmer/githubfetch/refs/he
 $ sudo chmod +x /usr/local/bin/githubfetch
 ```
 
+## To try it
+
+Clone repo
+
+```bash
+git pull git@github.com:isa-programmer/githubfetch.git
+```
+
+Move to githubfetch folder
+
+```bash
+cd githubfetch/
+```
+
+Create a virtual envieroment (Optional):
+
+* To Linux or MacOs:
+```bash
+python -m venv venv 
+. ./venv/bin/activate
+```
+
+* To Windows:
+
+```bash
+python -m venv venv
+venv\Scripts\activate
+```
+
+Install requirements:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run it:
+
+```bash
+python githubfetch.py <github-username>
+```
+
 ### Optional: Contribution heatmap
 Displaying the contribution heatmap along with basic user info requires a GitHub personal access token. Create one from [here](https://github.com/settings/tokens) with ```read:user``` scope, then add this line to your .bashrc or other shell config
 ```

--- a/githubfetch.py
+++ b/githubfetch.py
@@ -105,14 +105,20 @@ def display_contributions(weeks):
         print(line)
 
 def display_avatar(image_url):
-    try:
-        subprocess.run([
-                "kitten", "icat", "--align",
-                "left", "--scale-up", "--place",
-                "20x20@0x2", image_url])
-    except FileNotFoundError:
-        print(color.red,"Kitty Terminal not installed!", color.reset)
-        sys.exit(1)
+    commands = [
+        ["kitten", "icat", "--align", "left", "--scale-up", "--place", "20x20@0x2", image_url],
+        ["kitty", "+kitten", "icat", "--align", "left", "--scale-up", "--place", "20x20@0x2", image_url]
+    ]
+    
+    for cmd in commands:
+        try:
+            subprocess.run(cmd, check=True)
+            return  # Success
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            continue  # Try next command
+    
+    print(color.red, "Kitty Terminal not installed!", color.reset)
+    sys.exit(1)
 
 def display_user_info(data, starred_count, username):
     github_url = f"{username}@github.com"


### PR DESCRIPTION
I have the problem that it didn't show the image:

```bash 
"kitten", "icat", "--align", "left", "--scale-up", "--place", "20x20@0x2", image_url
```

And I fix it with this:

```bash 
"kitty", "+kitten", "icat", "--align", "left", "--scale-up", "--place", "20x20@0x2", image_url
```

So I added that if the first command failed it would execute the second one

```python
def display_avatar(image_url):
    commands = [
        ["kitten", "icat", "--align", "left", "--scale-up", "--place", "20x20@0x2", image_url],
        ["kitty", "+kitten", "icat", "--align", "left", "--scale-up", "--place", "20x20@0x2", image_url]
    ]
    
    for cmd in commands:
        try:
            subprocess.run(cmd, check=True)
            return  # Success
        except (FileNotFoundError, subprocess.CalledProcessError):
            continue  # Try next command
    
    print(color.red, "Kitty Terminal not installed!", color.reset)
    sys.exit(1)
```

And update the readme.md to try it locally


