### PR TITLE
feat : Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim AS build
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir --target=/tmp/deps -r requirements.txt
+
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY --from=build /tmp/deps /usr/local/lib/python3.12/site-packages
+
+COPY githubfetch.py .
+
+ENTRYPOINT ["python", "githubfetch.py"]

--- a/githubfetch.py
+++ b/githubfetch.py
@@ -109,14 +109,14 @@ def display_avatar(image_url):
         ["kitten", "icat", "--align", "left", "--scale-up", "--place", "20x20@0x2", image_url],
         ["kitty", "+kitten", "icat", "--align", "left", "--scale-up", "--place", "20x20@0x2", image_url]
     ]
-    
+
     for cmd in commands:
         try:
             subprocess.run(cmd, check=True)
             return  # Success
         except (FileNotFoundError, subprocess.CalledProcessError):
             continue  # Try next command
-    
+
     print(color.red, "Kitty Terminal not installed!", color.reset)
     sys.exit(1)
 
@@ -143,7 +143,7 @@ def display_user_info(data, starred_count, username):
     print("\n")
 
 
-## Rending ASCII
+## Rendering ASCII
 use_ascii = True
 align_bottom = False
 


### PR DESCRIPTION
Added a `Dockerfile` to enable running GitHubFetch directly via Docker.

Users can now run the tool in a fully containerized environment without needing to install Python, Pillow, or ImageMagick on their host machine.

Docker image supports all core features except Kitty-specific rendering.

The lack of native GUI/terminal access within containers, Kitty-specific image previews will not work.

ASCII rendering will be used as a fallback when run inside Docker.