### PR TITLE
use python alpine on dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim AS build
+FROM python:3.12-alpine AS build
 
 WORKDIR /app
 
@@ -6,7 +6,7 @@ COPY requirements.txt .
 
 RUN pip install --no-cache-dir --target=/tmp/deps -r requirements.txt
 
-FROM python:3.12-slim
+FROM python:3.12-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
This change is a **suggestion** for storage reasons:

```bash
 $ sudo docker images
REPOSITORY             TAG           IMAGE ID       CREATED          SIZE
githubfetch-alpine     latest        58d8517539d4   43 minutes ago   65.3MB
githubfetch-slim            latest        ae2e26719242   50 minutes ago   142MB
python                 3.12-slim     87760eb43bfd   8 days ago       124MB
python                 3.12-alpine   2d6c23e3d401   8 days ago       48.7MB
```

This results in a size reduction of nearly 55%, using Alpine helps optimize disk space and speed up image downloads