### PR TITLE
fix : Making ASCII format as a fallback

### DIFF
--- a/githubfetch.py
+++ b/githubfetch.py
@@ -329,7 +329,7 @@ if __name__ == "__main__":
             render_layout(ascii_block, info_block)
         else:
             if use_color:
-                ascii_block = display_avatar(user_data.get("avatar_url"), use_color=use_color)
+                ascii_block = display_avatar(user_data.get("avatar_url"))
                 if ascii_block:
                     info_block = get_user_info_lines(user_data, starred_count, username)
                     render_layout(ascii_block, info_block)


### PR DESCRIPTION
Improves fallback mechanism for avatar rendering. If image rendering fails due to unsupported terminal capabilities or any runtime error, the program now automatically:
- Displays a clear warning in the terminal
- Falls back to rendering an ASCII version of the GitHub avatar

![image](https://github.com/user-attachments/assets/a844e074-6eaf-42a9-9d77-784dcfa271d4)
